### PR TITLE
added NSBluetoothAlwaysUsageDescription key to plist 

### DIFF
--- a/BasicBrowser/Info.plist
+++ b/BasicBrowser/Info.plist
@@ -51,6 +51,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>APP implements webBLE; thus, the app needs access to bluetooth.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
added NSBluetoothAlwaysUsageDescription key to plist as iOS13 requires this when using bleframework

otherwise app will crash on iOS13 devices when APP has not been used before