### PR TITLE
Undefined / null checks for console log

### DIFF
--- a/WBCore/Polyfill/WBUtils.js
+++ b/WBCore/Polyfill/WBUtils.js
@@ -94,7 +94,9 @@ uk.co.greenparksoftware.wbutils = {
   };
   function consoleLog(level, message, ...args) {
     window.webkit.messageHandlers.logger.postMessage({level, message: `${message}`});
-    levelHandlers[level].call(window.console, message, ...args);
+    if (levelHandlers[level]) {
+        levelHandlers[level].call(window.console, message, ...args);
+    }
   }
   window.console = {
     debug: (...args) => consoleLog('debug', ...args),


### PR DESCRIPTION
Added check to prevent errors if some console functions are undefined / null. (Happens for example if you use 3rd party tools on websites, which mess around with the window.console object)

Sponsored by Zemtu (https://www.zemtu.com/)