### PR TITLE
Remove DEVELOPMENT_TEAM from project.pbxproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # WebBLE
 
 Initial partial implementation of the [Web Bluetooth](https://webbluetoothcg.github.io/web-bluetooth/) 
-spec for iOS. 
-
-This builds on [Paul Thierault](https://github.com/pauljt)'s [original implementation](https://github.com/pauljt/BleBrowser).
-
-The app is fundamentally a `WKWebView` with a polyfill providing the javascript APIs calling 
-through to the CoreBluetooth iOS API via a thin transaction management layer.
+spec for iOS, originally forked from [Paul Thierault](https://github.com/pauljt)'s [original implementation](https://github.com/pauljt/BleBrowser).
 
 WebBLE is licensed under the Apache Version 2.0 License as per the LICENSE file.
+
+### Distributions
+
+-  [WebBLE](https://apps.apple.com/gb/app/webble/id1193531073) was the first distribution and the one that I (daphtdazz) maintain and support. Purchasing this is the best way to support the project.
+
+Others are available on the app store which provide varying levels of support / alternative features.
+
+> If you would like to add your distribution to this list then please send a PR, but it should provide some extra functionality over WebBLE and not just be a direct clone.
+
 
 ## Supported APIs v1.0
 
@@ -56,5 +60,22 @@ WebBLE is licensed under the Apache Version 2.0 License as per the LICENSE file.
 - `.addEventListener()`
 - `.removeEventListener()`
 
-
 Everything else is TBD!
+
+## Development
+
+Info if you want to add features / fix bugs in the project.
+
+### Setup
+
+If you want to build and run locally, you just have to do the following:
+
+- Set your `DEVELOPMENT_TEAM` ID in Locations -> Custom Paths as per [this stackoverflow](https://stackoverflow.com/questions/39669661/how-to-prevent-xcode-8-from-saving-development-team-in-pbxproj/40424891#40424891) answer, which is to avoid pushing personal / conflicting team IDs to github. 
+
+### Testing
+
+Currently there are no unit tests... partly because it's time-consuming and difficult to write meaningful unit tests since there are three things to test: the javascript APIs, the native glue layer and the actual behaviour of a bluetooth device at the other end. Instead end-to-end tests which require some real devices to be used are hosted [here](https://www.greenparksoftware.co.uk/projects/webble/pucktest), and these tests are run / fixed before new versions of [WebBLE](https://apps.apple.com/gb/app/webble/id1193531073) are released to the App store.
+
+If you are maintaining your own release you can use those tests or write your own. If you want to spend the effort to start adding actual unit tests then that would be marvellous.
+
+> 💡 If you have a device you'd like me to add tests for please get in contact with me!

--- a/WebBLE.xcodeproj/project.pbxproj
+++ b/WebBLE.xcodeproj/project.pbxproj
@@ -569,7 +569,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 7UGU2CH934;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = BasicBrowser/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
@@ -587,7 +586,6 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 7UGU2CH934;
 				INFOPLIST_FILE = BasicBrowser/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
Use custom path hack as per [this](https://stackoverflow.com/questions/39669661/how-to-prevent-xcode-8-from-saving-development-team-in-pbxproj/40424891#40424891)