### PR TITLE
fix for service uuid sometimes turns into name like 'Device Informati…

### DIFF
--- a/WBCore/Jsonifiable.swift
+++ b/WBCore/Jsonifiable.swift
@@ -47,7 +47,7 @@ extension String: Jsonifiable {
 }
 extension CBUUID: Jsonifiable {
     func jsonify() -> String {
-        return "\"\(self)\""
+        return "\"\(self.uuidString)\""
     }
 }
 extension Array: Jsonifiable {


### PR DESCRIPTION
sometimes when parsing service name the uuid is the name of the service like 'Device Information' instead of expected service uuid format like
`const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;`